### PR TITLE
Remove all CUDA dependencies and utilize numba CPU acceleration

### DIFF
--- a/src/snc/helpers/distance_matrix.py
+++ b/src/snc/helpers/distance_matrix.py
@@ -1,71 +1,20 @@
-from numba import cuda
+import numba
 import numpy as np
-import math
-import time
 
 '''
-Distance Matrix Calculation Accelerated by GPGPU
+Distance Matrix Calculation Accelerated by Numba
 '''
 
-@cuda.jit
-def dist_matrix_kernel(vectors, sizes, dist_matrix):
-    ## Input 1: the list of vectors
-    ## Input 3: the size of each vector
-    ## Output : distance matrix
-    i = cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
-    j = cuda.threadIdx.y + cuda.blockIdx.y * cuda.blockDim.y
-
-    vsize = sizes[0]
-    isize = sizes[1]
-
-    if i >= isize or j >= isize:
-        return
-    if i == j:
-        dist_matrix[i, j] = 0
-        return
-    else:
-        dist = 0
-        for idx in range(vsize):
-            dist += (vectors[i, idx] - vectors[j, idx]) ** 2
-        dist_matrix[i, j] = math.sqrt(dist)
-            
-## GPU Accelerated Distance matrix calculation
-def dist_matrix_gpu(vectors):
-    vector_size = len(vectors[0])
-    item_num = len(vectors)
-
-    ## INPUT
-    vectors_global_mem = cuda.to_device(vectors)
-    sizes_global_mem = cuda.to_device(np.array([vector_size, item_num]))
-
-    ## OUTPUT
-    dist_matrix_global_mem = cuda.device_array((item_num, item_num))
-    
-    ## Run Kernel
-    TPB = 16
-    tpb = (TPB, TPB)   
-    bpg = (math.ceil(item_num / TPB), math.ceil(item_num / TPB))
-
-    dist_matrix_kernel[bpg, tpb](vectors_global_mem, sizes_global_mem, dist_matrix_global_mem)
-    
-    ## GET Result
-    dist_matrix = dist_matrix_global_mem.copy_to_host()
-
-    return dist_matrix
-
-## CPU Distance matrix calculation (for comparison & test)
-def dist_matrix_cpu(vectors):
-    vector_size = len(vectors[0])
-    item_num = len(vectors)
-
-    dist_matrix = np.zeros((item_num, item_num))
-
-    for i in range(item_num):
-        for j in range(i):
-            dist_matrix[i, j] = np.linalg.norm(vectors[i] - vectors[j])
-            dist_matrix[j, i] = dist_matrix[i, j]
-
-    return dist_matrix
+##  Distance matrix calculation
+@numba.njit(parallel=True)
+def dist_matrix(vectors):
+    distance_matrix = np.zeros((len(vectors), len(vectors)))
+    for i in numba.prange(len(vectors)):
+        for j in numba.prange(i + 1, len(vectors)):
+            # minutely faster than np.linalg.norm
+            distance_matrix[i][j] = np.sqrt(np.sum((vectors[i] - vectors[j]) ** 2))
+            distance_matrix[j][i] = distance_matrix[i][j]
+    return distance_matrix
 
 '''
 k-nearest neighbor implementation with 

--- a/src/snc/helpers/hparam_functions.py
+++ b/src/snc/helpers/hparam_functions.py
@@ -14,8 +14,8 @@ e.g., knn info, distance matrix...
 '''
 
 def get_euclidean_infos(raw, emb, dist_parameter, dist_function, length, k, snn_knn_matrix):
-    raw_dist_matrix = dm.dist_matrix_gpu(raw)
-    emb_dist_matrix = dm.dist_matrix_gpu(emb)
+    raw_dist_matrix = dm.dist_matrix(raw)
+    emb_dist_matrix = dm.dist_matrix(emb)
     
     raw_dist_max = np.max(raw_dist_matrix)
     emb_dist_max = np.max(emb_dist_matrix)
@@ -70,8 +70,8 @@ def get_snn_infos(raw, emb, dist_parameter, dist_function, length, k, snn_knn_ma
     infos = get_euclidean_infos(raw, emb, dist_parameter, dist_function, length, k, snn_knn_matrix)
     
     # Compute snn matrix
-    raw_snn_matrix = sk.snn_gpu(infos["raw_knn"], length, k)
-    emb_snn_matrix = sk.snn_gpu(infos["emb_knn"], length, k)
+    raw_snn_matrix = sk.snn(infos["raw_knn"], length, k)
+    emb_snn_matrix = sk.snn(infos["emb_knn"], length, k)
     raw_snn_max    = np.max(raw_snn_matrix)
     emb_snn_max    = np.max(emb_snn_matrix)
 

--- a/src/snc/helpers/snn_knn.py
+++ b/src/snc/helpers/snn_knn.py
@@ -1,50 +1,23 @@
-from numba import cuda
+import numba
 from sklearn.neighbors import NearestNeighbors
 from collections import deque
 
 import numpy as np
 import math
 
-'''
-GPU Acceleration for snn matrix Construction
-'''
-@cuda.jit
-def snn_kernel(knn_info, param_arr, snn_matrix):
-    ## Input: raw_knn (knn info)
-    ## Output: snn_matrix (snn info)
-    i = cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
-    j = cuda.threadIdx.y + cuda.blockIdx.y * cuda.blockDim.y
+@numba.njit(parallel=True)
+def snn(knn_info, length, k):
+    snn_matrix = np.zeros((length, length))
 
-    length = param_arr[0]
-    k      = param_arr[1]
-    if i >= length or j >= length:
-        return
-    if i == j:
-        snn_matrix[i, j] = 0
-        return
-    c = 0
-    for m in range(k):
-        for n in range(k):
-            if knn_info[i, m] == knn_info[j,n]:
-                c += (k + 1 - m) * (k + 1 - n)
-
-    snn_matrix[i, j] = c
-
-def snn_gpu(knn_info, length, k):
-    ## INPUT
-    knn_info_global_mem = cuda.to_device(knn_info)
-    param_arr_global_mem = cuda.to_device(np.array([length, k]))
-    ## OUTPUT
-    snn_matrix_global_mem = cuda.device_array((length, length))
-
-    TPB = 32
-    tpb = (TPB, TPB)
-    bpg = ((math.ceil(length / TPB), math.ceil(length / TPB)))
-
-    snn_kernel[bpg, tpb](knn_info_global_mem, param_arr_global_mem, snn_matrix_global_mem)
-
-    snn_matrix = snn_matrix_global_mem.copy_to_host()
-
+    for i in numba.prange(length):
+        for j in numba.prange(i, length):
+            c = 0
+            for m in numba.prange(k):
+                for n in numba.prange(k):
+                    if knn_info[i, m] == knn_info[j, n]:
+                        c += (k + 1 - m) * (k + 1 - n)
+            snn_matrix[i, j] = c
+            snn_matrix[j, i] = c
     return snn_matrix
 
 

--- a/src/snc/snc.py
+++ b/src/snc/snc.py
@@ -13,13 +13,15 @@ class SNC:
                  iteration=150,            # iteration number
                  walk_num_ratio=0.3,       # random walk number,
                  dist_strategy="snn",      # determines the way to compute distance 
-                 dist_parameter={          # parameters used to compute distance
-                     "alpha": 0.1, "k": "sqrt"
-                 },        
+                 dist_parameter=None,      # parameters used to compute distance
                  dist_function=None,       # inject predefined distance function
                  cluster_strategy="dbscan", # determines the way to consider clusters
                  snn_knn_matrix=None,  # inject predefined similarity matrix (dist_strategy should be "inject_snn")
                 ):
+        if dist_parameter is None:
+            dist_parameter = {
+                "alpha": 0.1, "k": "sqrt"
+            }
         self.raw  = np.array(raw, dtype=np.float64)
         self.emb  = np.array(emb, dtype=np.float64)
         self.N    = len(raw)    # number of points


### PR DESCRIPTION
This PR removes all usages of numba.cuda from the codebase, and replaces it with appropriately accelerated CPU code.

In addition, a mutable default argument has been refactored out using the `is None` convention to prevent potential bugs.