### PR TITLE
Fix dtype issue in `get_inject_snn_infos` function when using `dist_strategy="inject_snn"` and unnecessary white-space removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ cython_debug/
 #.idea/
 
 # End of https://www.toptal.com/developers/gitignore/api/python
+.qodo

--- a/src/snc/helpers/hparam_functions.py
+++ b/src/snc/helpers/hparam_functions.py
@@ -16,21 +16,21 @@ e.g., knn info, distance matrix...
 def get_euclidean_infos(raw, emb, dist_parameter, dist_function, length, k, snn_knn_matrix):
     raw_dist_matrix = dm.dist_matrix(raw)
     emb_dist_matrix = dm.dist_matrix(emb)
-    
+
     raw_dist_max = np.max(raw_dist_matrix)
     emb_dist_max = np.max(emb_dist_matrix)
 
     raw_dist_matrix /= raw_dist_max
     emb_dist_matrix /= emb_dist_max
 
-    raw_knn_info = sk.knn_info(raw_dist_matrix, k) 
-    emb_knn_info = sk.knn_info(emb_dist_matrix, k) 
+    raw_knn_info = sk.knn_info(raw_dist_matrix, k)
+    emb_knn_info = sk.knn_info(emb_dist_matrix, k)
 
     return {
         "raw_dist_matrix" : raw_dist_matrix,
-        "emb_dist_matrix" : emb_dist_matrix, 
+        "emb_dist_matrix" : emb_dist_matrix,
         "raw_dist_max"    : raw_dist_max,
-        "emb_dist_max"    : emb_dist_max, 
+        "emb_dist_max"    : emb_dist_max,
         "raw_knn"         : raw_knn_info,
         "emb_knn"         : emb_knn_info
     }
@@ -43,21 +43,21 @@ def get_predefined_infos(raw, emb, dist_parameter, dist_function, length, k, snn
         for j in range(length):
             raw_dist_matrix[i, j] = dist_function(raw[i], raw[j], dist_parameter)
             emb_dist_matrix[i, j] = dist_function(emb[i], emb[i], dist_parameter)
-    
+
     raw_dist_max = np.max(raw_dist_matrix)
     emb_dist_max = np.max(emb_dist_matrix)
 
     raw_dist_matrix /= raw_dist_max
     emb_dist_matrix /= emb_dist_max
 
-    raw_knn_info = sk.knn_info(raw_dist_matrix, k) 
-    emb_knn_info = sk.knn_info(emb_dist_matrix, k) 
+    raw_knn_info = sk.knn_info(raw_dist_matrix, k)
+    emb_knn_info = sk.knn_info(emb_dist_matrix, k)
 
     return {
         "raw_dist_matrix" : raw_dist_matrix,
-        "emb_dist_matrix" : emb_dist_matrix, 
+        "emb_dist_matrix" : emb_dist_matrix,
         "raw_dist_max"    : raw_dist_max,
-        "emb_dist_max"    : emb_dist_max, 
+        "emb_dist_max"    : emb_dist_max,
         "raw_knn"         : raw_knn_info,
         "emb_knn"         : emb_knn_info
     }
@@ -68,7 +68,7 @@ def get_predefined_infos(raw, emb, dist_parameter, dist_function, length, k, snn
 def get_snn_infos(raw, emb, dist_parameter, dist_function, length, k, snn_knn_matrix):
 
     infos = get_euclidean_infos(raw, emb, dist_parameter, dist_function, length, k, snn_knn_matrix)
-    
+
     # Compute snn matrix
     raw_snn_matrix = sk.snn(infos["raw_knn"], length, k)
     emb_snn_matrix = sk.snn(infos["emb_knn"], length, k)
@@ -95,24 +95,24 @@ def get_inject_snn_infos(raw, emb, dist_parameter, dist_function, length, k, snn
     infos = {}
     infos["raw_knn"] = snn_knn_matrix["raw_knn"]
     infos["emb_knn"] = snn_knn_matrix["emb_knn"]
-    
+
     infos["raw_snn_matrix"] = snn_knn_matrix["raw_snn"]
     infos["emb_snn_matrix"] = snn_knn_matrix["emb_snn"]
-    
+
     raw_snn_max		= np.max(infos["raw_snn_matrix"])
     emb_snn_max		= np.max(infos["emb_snn_matrix"])
-    
-    infos["raw_snn_matrix"] /= raw_snn_max
-    infos["emb_snn_matrix"] /= emb_snn_max
-    
+
+    infos["raw_snn_matrix"] = infos["raw_snn_matrix"] / raw_snn_max
+    infos["emb_snn_matrix"] = infos["emb_snn_matrix"] / emb_snn_max
+
     infos["raw_dist_matrix"] = 1 / (infos["raw_snn_matrix"] + dist_parameter["alpha"])
     infos["emb_dist_matrix"] = 1 / (infos["emb_snn_matrix"] + dist_parameter["alpha"])
-    
+
     return infos
 
 '''
 Helper functions to extract a cluster
-used to extract_cluster 
+used to extract_cluster
 '''
 
 def get_a_cluster_snn(infos, mode, seed_idx, walk_num):
@@ -122,7 +122,7 @@ def get_a_cluster_snn(infos, mode, seed_idx, walk_num):
     if mode == "cohesiveness": ## extract from the original space
         knn_info   = infos["raw_knn"]
         snn_matrix = infos["raw_snn_matrix"]
-    
+
     return sk.snn_based_cluster_extraction(knn_info, snn_matrix, seed_idx, walk_num)
 
 def get_a_cluster_naive(infos, mode, seed_idx, walk_num):
@@ -130,7 +130,7 @@ def get_a_cluster_naive(infos, mode, seed_idx, walk_num):
         knn_info = infos["emb_knn"]
     if mode == "cohesiveness":
         knn_info = infos["raw_knn"]
-    
+
     return sk.naive_cluster_extraction(knn_info, seed_idx, walk_num)
 
 
@@ -221,11 +221,11 @@ INSTALLING Hyperparameter functions
 def install_hparam(dist_strategy, dist_parameter, dist_function, cluster_strategy, snn_knn_matrix, raw, emb):
     get_infos = None
     get_a_cluster = None
-    get_clusterinng = None 
+    get_clusterinng = None
     get_cluster_distance = None
 
     ## Prepare proper functions for distance strategy
-    if dist_strategy == "snn": 
+    if dist_strategy == "snn":
         get_infos = get_snn_infos
         get_a_cluster = get_a_cluster_snn
         get_cluster_distance = get_snn_cluster_distance
@@ -262,7 +262,7 @@ def install_hparam(dist_strategy, dist_parameter, dist_function, cluster_strateg
         raw, emb, dist_parameter, dist_function,
         get_infos, get_a_cluster, get_clustering, get_cluster_distance, snn_knn_matrix
     )
-    
+
 
 class HparamFunctions():
     '''
@@ -299,7 +299,7 @@ class HparamFunctions():
 
     '''
     Extract the clusters from the given incidices
-    mode : steadiness / cohesiveness 
+    mode : steadiness / cohesiveness
     '''
     def extract_cluster(self, mode, walk_num):
         seed_idx = np.random.randint(self.length)
@@ -309,12 +309,12 @@ class HparamFunctions():
             if cluster_candidate.size > 1:
                 extracted_cluster = cluster_candidate
         return extracted_cluster
-    
+
 
     '''
     Get the indices of the points which to be clustered as input
     and return the clustereing result
-    mode : steadiness / cohesiveness 
+    mode : steadiness / cohesiveness
     '''
     def clustering(self, mode, indices):
         if mode == "steadiness":
@@ -323,9 +323,9 @@ class HparamFunctions():
         if mode == "cohesiveness":
             dist_matrix = self.infos["emb_dist_matrix"]
             data = self.emb
-        
+
         return self.get_clustering(dist_matrix, data, indices, self.dist_parameter)
-    
+
     '''
     Compute the distance between two clusters in raw / emb space
     return two distance (raw_dist, emb_dist)


### PR DESCRIPTION
This PR addresses an issue in the `snc` package (version 2.6.0) when utilizing precomputed SNN and KNN matrices with `dist_strategy="inject_snn"`.

I am using it with the injection of SNN and KNN as I have already precomputed as I used them for other measurements, and since my datasets are vast, I preferred injection. Here is my sample code:

```python
snc_obj = SNC(
        orig,
        emb,
        iteration=iteration,
        walk_num_ratio=walk_num_ratio,
        dist_strategy="inject_snn",
        dist_parameter={"alpha": alpha},
        dist_function=None,
        cluster_strategy=clustering_strategy,
        snn_knn_matrix={
            "raw_knn": orig_knn_indices, # matrix of np.int32
            "raw_snn": orig_snn_graph, # matrix of np.int32
            "emb_knn": emb_knn_indices, # matrix of np.int32
            "emb_snn": emb_snn_graph, # matrix of np.int32
        },
    )
snc_obj.fit(record_vis_info=True)
steadiness, cohesiveness = float(snc_obj.steadiness()), float(snc_obj.cohesiveness())
snc_vis_info = snc_obj.vis_info()
```
However, after running the code,  I was getting the error:

```
FuncTypeError: Cannot cast ufunc 'divide' output from dtype('float64') to  dtype('int64') with casting rule 'same_kind'
```
This is caused by in-place division, which seems to originate from [these lines](https://github.com/hj-n/steadiness-cohesiveness/blob/master/src/snc/helpers/hparam_functions.py#L105-L106):

```python
infos["raw_snn_matrix"] /= raw_snn_max
infos["emb_snn_matrix"] /= emb_snn_max
```
This behavior change is documented in [NumPy's release notes](https://github.com/numpy/numpy/pull/6499/files):

> Default casting for inplace operations has changed to `'same_kind'`. For instance, if `n` is an array of integers, and `f` is an array of floats, then `n += f` will result in a `TypeError`, whereas in previous NumPy versions, the floats would be silently cast to ints.


A suggested workaround from the  [README.md](https://github.com/hj-n/steadiness-cohesiveness/blob/master/README.md?plain=1#L161-L165) is to convert all matrices to floating-point arrays. However, this solution introduces another downstream error during the execution of the `steadiness()` method:

```
/usr/local/lib/python3.11/site-packages/snc/helpers/snn_knn.py:48 in snn_based_cluster_extraction
probability = 1 - snn_matrix[i, j]

IndexError: arrays used as indices must be of integer (or boolean) type

Locals at time of error:
  cluster_member = {654}
  current_queue = deque([])
  i = 654
  j = 2198.0
  knn_info = array([[8973., 3261., 6872., ..., 1620.,  643., 4910.],
                    [3675., 2732.,  604., ..., 5820., 6851., 2223.],
                    ...])
  knns = array([2198., 9191., 1615., 1602., 3455., 5539., 4902.,
                921., 3851., 7465., 9978., 9681., 4041., 2201., 9421.])
  seed_idx = 654
  snn_matrix = array([[0., 0., 0., ..., 0., 0., 0.],
                      [0., 0., 0., ..., 0., 0., 0.],
                      ...])
  visit_num = 0
  walk_num = 3000
```
**Solution:**  
Replace the in-place division with the standard division to ensure integer arrays are properly cast to floating-point arrays:

```python
infos["raw_snn_matrix"] = infos["raw_snn_matrix"] / raw_snn_max
infos["emb_snn_matrix"] = infos["emb_snn_matrix"] / emb_snn_max
```

Additionally, I removed some unnecessary white-spaces.